### PR TITLE
添加了通过Monkey-patch实现在LLamaFactory下QLora的代码

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ python weclone/server/api_service.py
 ### 使用QLoRA微调
 由于 LlamaFactory 暂未提供直接暴露和管理量化参数（`BitsAndBytesConfig`）的接口，使得在使用 QLoRA 4-bit 量化时，需要修改框架内部模型加载方法。我们通过 Monkey-patch 的方式：在运行脚本最前面，统一注入 `quantization_config`，从而对所有调用 `AutoModelForCausalLM.from_pretrained` 的地方生效。
 
-**使用方法：**在你的训练脚本和推理脚本开头，只需引入并调用：
+#### 使用方法
+
+在你的训练脚本和推理脚本开头，只需引入并调用：
 
 ```python
 from weclone.utils.qlora_patch import apply_qlora_patch

--- a/README.md
+++ b/README.md
@@ -121,7 +121,32 @@ python weclone/eval/web_demo.py
 python weclone/server/api_service.py
 ```
 
+### 使用QLoRA微调
+由于 LlamaFactory 暂未提供直接暴露和管理量化参数（`BitsAndBytesConfig`）的接口，使得在使用 QLoRA 4-bit 量化时，需要修改框架内部模型加载方法。我们通过 Monkey-patch 的方式：在运行脚本最前面，统一注入 `quantization_config`，从而对所有调用 `AutoModelForCausalLM.from_pretrained` 的地方生效。
+
+**使用方法：**在你的训练脚本和推理脚本开头，只需引入并调用：
+
+```python
+from weclone.utils.qlora_patch import apply_qlora_patch
+
+# 在任何 transformers import 之前调用
+apply_qlora_patch()
+
+# 然后正常导入和运行其余逻辑
+from llamafactory.train.tuner import run_exp
+# ... 训练代码 ...
+```
+
+```python
+from weclone.utils.qlora_patch import apply_qlora_patch
+apply_qlora_patch()
+
+from llamafactory.webui.interface import create_web_demo
+# ... 推理代码 ...
+```
+
 ### 使用常见聊天问题测试
+
 有些答案比较抽象，主要原因是训练数据没有覆盖，后续通过ＲＡＧ来解决。测试结果在test_result-my.txt。
 ```bash
 python weclone/server/api_service.py

--- a/weclone/utils/qlora_patch.py
+++ b/weclone/utils/qlora_patch.py
@@ -1,0 +1,30 @@
+import torch
+from transformers import AutoModelForCausalLM, BitsAndBytesConfig
+
+__original_from_pretrained = AutoModelForCausalLM.from_pretrained
+
+def apply_qlora_patch():
+    """
+    Monkey-patch AutoModelForCausalLM.from_pretrained，
+    将所有模型加载统一应用 4-bit QLoRA 配置。
+
+    配置参数说明：
+    - load_in_4bit=True：启用 4-bit 量化，显存占用大幅降低
+    - bnb_4bit_quant_type="nf4"：选择 NF4 量化策略，兼顾精度与模型大小
+    - bnb_4bit_compute_dtype=torch.float16：推理/训练时使用半精度进行计算，进一步节省显存
+    - bnb_4bit_use_double_quant=True：双重量化，提升量化效果和模型性能
+    """
+    def _patched_from_pretrained(*args, **kwargs):
+        qlora_config = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=torch.float16,
+            bnb_4bit_use_double_quant=True
+        )
+        # Remove conflicting arg if present
+        kwargs.pop("load_in_4bit", None)
+        # Inject QLoRA config
+        kwargs["quantization_config"] = qlora_config
+        return __original_from_pretrained(*args, **kwargs)
+
+    AutoModelForCausalLM.from_pretrained = _patched_from_pretrained


### PR DESCRIPTION
由于 LlamaFactory 暂未提供直接暴露和管理量化参数（`BitsAndBytesConfig`）的接口，使得在使用 QLoRA 4-bit 量化时，需要修改框架内部模型加载方法。
因此添加了通过Monkey-patch实现在LLamaFactory下QLora的代码，使用时训练或者推理代码前import并调用对应函数即可

```python
from weclone.utils.qlora_patch import apply_qlora_patch
# 在任何 transformers import 之前调用
apply_qlora_patch()
```