### PR TITLE
fix: fix triton source from default cuda129 to 126

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,10 @@ torchvision = [
   { index = "pytorch-cu126", marker = "platform_system == 'Windows'" },
   { index = "pytorch-cu126", marker = "platform_system == 'Linux'" },
 ]
+triton = [
+  { index = "pytorch-cu126", marker = "platform_system == 'Windows'" },
+  { index = "pytorch-cu126", marker = "platform_system == 'Linux'" },
+]
 
 
 [[tool.uv.index]]


### PR DESCRIPTION
By default, without declaring triton's index, `uv pip install --group main -e .` will give the following output, saying that there exists a conflict in dependencies :

```
(.venv) root@7a780b37eb00:/workspaces/weclone/WeClone# uv pip install --group main -e . 
  × No solution found when resolving dependencies:
  ╰─▶ Because only the following versions of torch{sys_platform == 'linux'} are available:
          torch{sys_platform == 'linux'}<2.7.1
          torch{sys_platform == 'linux'}>=2.7.1+cu126
      and torch==2.7.1+cu126 depends on system:cuda==12.6, we can conclude that torch{sys_platform == 'linux'}==2.7.1 depends
      on system:cuda==12.6.
      And because triton==3.3.1 depends on system:cuda==12.9, we can conclude that torch{sys_platform == 'linux'}==2.7.1 and
      triton{sys_platform == 'linux'}==3.3.1 are incompatible.
      And because you require torch{sys_platform == 'linux'}==2.7.1 and triton{sys_platform == 'linux'}==3.3.1, we can conclude
      that your requirements are unsatisfiable.
```

Fixing triton's index to pytorch-cu126 solves this problem.