### PR TITLE
fix: add dtype config option to VllmArgs for older GPU support

### DIFF
--- a/settings.template.jsonc
+++ b/settings.template.jsonc
@@ -91,8 +91,9 @@
     },
     "vllm_args": {
         "gpu_memory_utilization": 0.9,
+        // "dtype": "float16", // For GPUs with compute capability < 8.0 (e.g., Tesla T4, V100) that don't support bfloat16
         // "data_parallel_size": 2,
-        // "quantization": "bitsandbytes", 
+        // "quantization": "bitsandbytes",
         // "load_format": "bitsandbytes"
     },
     "test_model_args": {

--- a/weclone/utils/config_models.py
+++ b/weclone/utils/config_models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Literal, Optional
 
 from loguru import logger
 from pydantic import BaseModel, Field, model_validator
@@ -207,11 +207,12 @@ class InferArgs(BaseConfigModel):
 
 class VllmArgs(BaseConfigModel):
     gpu_memory_utilization: float = Field(default=0.9, description="vllm GPU memory utilization")
-    dtype: Optional[str] = Field(
+    dtype: Optional[Literal["auto", "float16", "bfloat16", "float32", "half", "bf16"]] = Field(
         default=None,
         description=(
-            "Data type for vLLM inference. Set to 'float16' for GPUs with compute capability < 8.0 "
-            "(e.g., Tesla T4, V100) that do not support bfloat16."
+            "Data type for vLLM inference. Use 'float16' (or its alias 'half') for GPUs with "
+            "compute capability < 8.0 (e.g. Tesla T4, V100) that do not support bfloat16. "
+            "Allowed values: 'auto', 'float16', 'bfloat16', 'float32', 'half', 'bf16'."
         ),
     )
 

--- a/weclone/utils/config_models.py
+++ b/weclone/utils/config_models.py
@@ -207,6 +207,13 @@ class InferArgs(BaseConfigModel):
 
 class VllmArgs(BaseConfigModel):
     gpu_memory_utilization: float = Field(default=0.9, description="vllm GPU memory utilization")
+    dtype: Optional[str] = Field(
+        default=None,
+        description=(
+            "Data type for vLLM inference. Set to 'float16' for GPUs with compute capability < 8.0 "
+            "(e.g., Tesla T4, V100) that do not support bfloat16."
+        ),
+    )
 
 
 class TestModelArgs(BaseConfigModel):


### PR DESCRIPTION
Fixes #85

## Problem

GPUs with compute capability < 8.0 (e.g., Tesla T4, V100) do not support bfloat16. When running the `make-dataset` command with data cleaning enabled (`enable_clean: true`), vLLM defaults to bfloat16 (inherited from the model config), causing:

```
ValueError: Bfloat16 is only supported on GPUs with compute capability of at least 8.0.
Your Tesla T4 GPU has compute capability 7.5. You can use float16 instead...
```

The CLI flag `--dtype=half` cannot be passed through the existing interface, leaving users with no configuration-level workaround.

## Solution

Add an explicit `dtype` field to `VllmArgs` in `config_models.py`. When set, it is propagated to the vLLM engine via the existing `engine_args.update(wc_vllm_dict)` path in `offline_infer.py`.

Users on older GPUs can now set the following in their `settings.jsonc`:

```jsonc
"vllm_args": {
    "gpu_memory_utilization": 0.9,
    "dtype": "float16"
}
```

The field defaults to `None`, preserving the existing behaviour (vLLM chooses dtype automatically) for all other users.

Also added a commented-out example in `settings.template.jsonc` to make this option discoverable.

## Testing

- Verified the fix path: `VllmArgs.dtype` is included in `wc_vllm_dict` (non-None filter passes), and `engine_args.update(wc_vllm_dict)` overrides the default `model_args.infer_dtype`.
- No behaviour change when `dtype` is not set in config.

## Sourcery 总结

为 vLLM 推理参数添加可配置的 dtype 支持，以便在不支持 bfloat16 的 GPU 上运行。

新特性：
- 在 `VllmArgs` 中引入可选的 `dtype` 字段，允许通过配置覆盖 vLLM 推理的默认数据类型。

文档：
- 通过在设置模板配置中添加带注释的示例，对新的 vLLM `dtype` 选项进行文档说明。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

允许用户配置 vLLM 推理数据类型，使较旧的 GPU 能够避免执行不受支持的 bfloat16，同时默认保留自动数据类型选择。

新功能：
- 添加可选的 vLLM 数据类型配置，以支持在较旧的 GPU 上选择兼容的精度。

错误修复：
- 通过允许选择 float16 或等效数据类型，使数据清理推理能够在不支持 bfloat16 的 GPU 上运行。

文档：
- 在设置模板中通过带注释的示例记录 vLLM 数据类型选项。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

允许用户配置 vLLM 推理数据类型；未提供覆盖设置时，仍保留自动数据类型选择功能。

新功能：
- 添加可选的 vLLM 数据类型配置设置，以支持选择与 GPU 兼容的推理精度。

错误修复：
- 通过允许选择 float16 或等效数据类型，支持在不支持 bfloat16 的旧款 GPU 上进行数据清理推理。

文档：
- 在设置模板中通过带注释的示例，记录 vLLM 数据类型选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow users to configure the vLLM inference dtype while preserving automatic dtype selection when no override is provided.

New Features:
- Add an optional vLLM dtype configuration setting to support selecting GPU-compatible inference precision.

Bug Fixes:
- Enable data-cleaning inference on older GPUs that do not support bfloat16 by allowing float16 or equivalent dtype selection.

Documentation:
- Document the vLLM dtype option with a commented example in the settings template.

</details>

</details>

</details>