### PR TITLE
fix: check API server availability before running test-model

### DIFF
--- a/weclone/eval/test_model.py
+++ b/weclone/eval/test_model.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from typing import List, cast  # 导入 cast
 
 import openai
@@ -8,6 +9,7 @@ from tqdm import tqdm
 
 from weclone.utils.config import load_config
 from weclone.utils.config_models import TestModelArgs, WCInferConfig
+from weclone.utils.log import logger
 
 infer_config = cast(WCInferConfig, load_config("web_demo"))
 test_config = cast(TestModelArgs, load_config("test_model"))
@@ -21,6 +23,21 @@ completion_config = {
 completion_config = type("Config", (object,), completion_config)()
 
 client = OpenAI(api_key="""sk-test""", base_url="http://127.0.0.1:8005/v1")
+
+
+def _check_api_server() -> None:
+    """Verify that the API server is running before starting tests.
+
+    Exits with an error message if the server is not reachable.
+    """
+    try:
+        client.models.list()
+    except openai.APIConnectionError:
+        logger.error(
+            "Cannot connect to the API server at http://127.0.0.1:8005. "
+            "Please start the server first by running: weclone-cli server"
+        )
+        sys.exit(1)
 
 
 def handler_text(content: str, history: list, config):
@@ -47,6 +64,7 @@ def handler_text(content: str, history: list, config):
 
 
 def main():
+    _check_api_server()
     test_list = json.loads(open(test_config.test_data_path, "r", encoding="utf-8").read())["questions"]
     res = []
     for questions in tqdm(test_list, desc=" Testing..."):

--- a/weclone/eval/test_model.py
+++ b/weclone/eval/test_model.py
@@ -34,7 +34,7 @@ def _check_api_server() -> None:
         client.models.list()
     except openai.APIConnectionError:
         logger.error(
-            "Cannot connect to the API server at http://127.0.0.1:8005. "
+            f"Cannot connect to the API server at {client.base_url}. "
             "Please start the server first by running: weclone-cli server"
         )
         sys.exit(1)


### PR DESCRIPTION
Fixes #115

## Problem

When a user runs `weclone-cli test-model` without first starting the API server (`weclone-cli server`), the command fails immediately with a cryptic `ConnectionRefusedError` / `APIConnectionError` traceback that gives no guidance on the root cause.

## Solution

Add a `_check_api_server()` helper that calls `client.models.list()` (a lightweight GET `/v1/models` probe) at the top of `main()`. If the server is unreachable, a clear, actionable error message is printed:

```
Cannot connect to the API server at http://127.0.0.1:8005.
Please start the server first by running: weclone-cli server
```

The process then exits with code 1 instead of spilling a stack trace.

## Testing

- Start `weclone-cli test-model` **without** the server running → see the new error message and exit code 1.
- Start `weclone-cli server`, then run `weclone-cli test-model` → proceeds normally as before.

## Summary by Sourcery

错误修复：
- 通过在退出前检查 API 服务器是否可达，并在失败时给出用户友好的错误信息，防止 `test-model` 在连接问题时仅报出无用的回溯错误并导致失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent test-model from failing with an unhelpful connection traceback by checking API server reachability and exiting with a user-friendly error message.

</details>