### PR TITLE
merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,6 @@
 [25/07/10] Data source added Telegram   
 [25/06/05] Support for image modal data fine-tuning    
 
-### Online Fine-Tuning
-- Big Model Lab (Lab4AI) (with 50 CNY voucher): https://www.lab4ai.cn/project/detail?utm_source=weclone1&id=ab83d14684fa45d197f67eddb3d8316c&type=project
-
 ### Hardware Requirements
 
 The project uses Qwen2.5-VL-7B-Instruct model by default with LoRA method for SFT stage fine-tuning. You can also use other models and methods supported by [LLaMA Factory](https://github.com/hiyouga/LLaMA-Factory/tree/main#supported-models).

--- a/README.md
+++ b/README.md
@@ -252,12 +252,7 @@ Thanks to the following code contributors and other community members for their 
 </a>
 
 This project also benefits from excellent open source projects such as [PyWxDump](https://github.com/xaoyaoo/PyWxDump), [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory), [AstrBot](https://github.com/AstrBotDevs/AstrBot), [LangBot](https://github.com/RockChinQ/LangBot), and others.
-<p>This project is supported by:</p>
-<p>
-  <a href="https://www.digitalocean.com/">
-    <img src="https://opensource.nyc3.cdn.digitaloceanspaces.com/attribution/assets/SVG/DO_Logo_horizontal_blue.svg" width="201px">
-  </a>
-</p>
+
 
 ## ⚠️ Disclaimer
 > [!CAUTION]

--- a/README_zh.md
+++ b/README_zh.md
@@ -64,9 +64,6 @@
 [25/06/05]支持图片模态数据微调   
 [25/07/10]数据源增加Telegram
 
-### 在线微调
-- 大模型实验室 (Lab4AI) (送50元代金券): https://www.lab4ai.cn/project/detail?utm_source=weclone1&id=ab83d14684fa45d197f67eddb3d8316c&type=project
-
 ### 硬件要求
 
 项目默认使用Qwen2.5-7B-Instruct模型，LoRA方法对sft阶段微调，大约需要16GB显存。也可以使用[LLaMA Factory](https://github.com/hiyouga/LLaMA-Factory/blob/main/README_zh.md#%E6%A8%A1%E5%9E%8B)支持的其他模型和方法。

--- a/weclone/eval/test_model.py
+++ b/weclone/eval/test_model.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from typing import List, cast  # 导入 cast
 
 import openai
@@ -8,6 +9,7 @@ from tqdm import tqdm
 
 from weclone.utils.config import load_config
 from weclone.utils.config_models import TestModelArgs, WCInferConfig
+from weclone.utils.log import logger
 
 infer_config = cast(WCInferConfig, load_config("web_demo"))
 test_config = cast(TestModelArgs, load_config("test_model"))
@@ -21,6 +23,21 @@ completion_config = {
 completion_config = type("Config", (object,), completion_config)()
 
 client = OpenAI(api_key="""sk-test""", base_url="http://127.0.0.1:8005/v1")
+
+
+def _check_api_server() -> None:
+    """Verify that the API server is running before starting tests.
+
+    Exits with an error message if the server is not reachable.
+    """
+    try:
+        client.models.list()
+    except openai.APIConnectionError:
+        logger.error(
+            "Cannot connect to the API server at http://127.0.0.1:8005. "
+            "Please start the server first by running: weclone-cli server"
+        )
+        sys.exit(1)
 
 
 def handler_text(content: str, history: list, config):
@@ -47,6 +64,7 @@ def handler_text(content: str, history: list, config):
 
 
 def main():
+    _check_api_server()
     test_list = json.loads(open(test_config.test_data_path, "r", encoding="utf-8").read())["questions"]
     res = []
     for questions in tqdm(test_list, desc=" Testing..."):

--- a/weclone/eval/test_model.py
+++ b/weclone/eval/test_model.py
@@ -34,7 +34,7 @@ def _check_api_server() -> None:
         client.models.list()
     except openai.APIConnectionError:
         logger.error(
-            "Cannot connect to the API server at http://127.0.0.1:8005. "
+            f"Cannot connect to the API server at {client.base_url}. "
             "Please start the server first by running: weclone-cli server"
         )
         sys.exit(1)

--- a/weclone/train/train_sft.py
+++ b/weclone/train/train_sft.py
@@ -40,7 +40,11 @@ def main():
     formatted_config = json.dumps(train_config.model_dump(mode="json"), indent=4, ensure_ascii=False)
     logger.info(f"Fine-tuning configuration:\n{formatted_config}")
 
-    run_exp(train_config.model_dump(mode="json"))
+    # Build config dict and remove nested 'quantization' key (its fields are already flattened at top level)
+    config_dict = train_config.model_dump(mode="json", exclude_none=True)
+    config_dict.pop("quantization", None)
+
+    run_exp(config_dict)
 
 
 if __name__ == "__main__":

--- a/weclone/utils/config.py
+++ b/weclone/utils/config.py
@@ -47,6 +47,17 @@ def load_base_config() -> WcConfig:
     return wc_config
 
 
+def _flatten_quantization_args(train_sft_args) -> dict:
+    """Extract quantization sub-config and return as a flat dict with non-None values.
+
+    LLaMA-Factory expects quantization params at the top level of the argument
+    namespace (e.g. ``--quantization_bit 4``), not nested under a ``quantization``
+    prefix. This helper flattens the nested ``QuantizationArgs`` model so it can
+    be merged directly into the config dict passed to HfArgumentParser.
+    """
+    return train_sft_args.quantization.get_non_none_dict()
+
+
 def create_config_by_arg_type(arg_type: str, wc_config: WcConfig) -> BaseModel:
     """Create corresponding configuration object based on argument type, merge common_config"""
     if arg_type == "cli_args":
@@ -55,7 +66,13 @@ def create_config_by_arg_type(arg_type: str, wc_config: WcConfig) -> BaseModel:
     common_config = wc_config.common_args.model_dump()
 
     if arg_type == "web_demo" or arg_type == "api_service":
-        config_dict = {**common_config, **wc_config.infer_args.model_dump()}
+        # Inherit quantization settings from train_sft_args for inference
+        quant_dict = _flatten_quantization_args(wc_config.train_sft_args)
+        config_dict = {
+            **common_config,
+            **wc_config.infer_args.model_dump(),
+            **quant_dict,
+        }
         return WCInferConfig(**config_dict)
 
     elif arg_type == "vllm":
@@ -66,12 +83,18 @@ def create_config_by_arg_type(arg_type: str, wc_config: WcConfig) -> BaseModel:
 
     elif arg_type == "train_sft":
         common_config["include_type"] = wc_config.make_dataset_args.include_type
-        config_dict = {**common_config, **wc_config.train_sft_args.model_dump()}
+
+        # Merge training params; flatten the nested quantization sub-config
+        train_dict = wc_config.train_sft_args.model_dump()
+        # Remove the nested "quantization" dict — its fields are flattened below
+        train_dict.pop("quantization", None)
+        train_dict.update(_flatten_quantization_args(wc_config.train_sft_args))
+
+        config_dict = {**common_config, **train_dict}
         return WCTrainSftConfig(**config_dict)
 
     elif arg_type == "make_dataset":
         make_dataset_config = wc_config.make_dataset_args.model_dump()
-        # TODO: Should the following three parameters be moved to common?
         train_sft_args = wc_config.train_sft_args
         extra_values = {
             "dataset": train_sft_args.dataset,

--- a/weclone/utils/config_models.py
+++ b/weclone/utils/config_models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Literal, Optional
 
 from loguru import logger
 from pydantic import BaseModel, Field, model_validator
@@ -135,7 +135,7 @@ class MakeDatasetArgs(BaseConfigModel):
     max_image_num: int = Field(2, description="Maximum number of images per single data entry")
     blocked_words: List[str] = Field([], description="List of blocked words")
     add_time: bool = Field(False, description="Whether to add time to the dataset")
-    add_relation: bool = Field(False, description="Whether to add chat member relationship to the dataset")
+    add_relation: bool = Field(False, description="Whether to add chat relation to the dataset")
     single_combine_strategy: CombineStrategy = Field(
         CombineStrategy.TIME_WINDOW,
         description="Strategy for combining single person's messages into a single sentence",
@@ -163,6 +163,40 @@ class MakeDatasetArgs(BaseConfigModel):
     )
     clean_batch_size: int = Field(10, description="Batch size for data cleaning")
     vision_api: VisionApiConfig = Field(VisionApiConfig())
+    pure_text: bool = Field(False, description="Whether to use pure text mode (disable vision encoder)")
+
+
+class QuantizationArgs(BaseConfigModel):
+    """Quantization arguments aligned with LLaMA-Factory QuantizationArguments.
+
+    These parameters are passed directly to LLaMA-Factory's HfArgumentParser
+    for both training and inference. LLaMA-Factory internally maps
+    ``quantization_bit`` to ``BitsAndBytesConfig(load_in_4bit/load_in_8bit)``,
+    so there is no need to expose ``load_in_4bit`` / ``load_in_8bit`` directly.
+
+    Reference: LLaMA-Factory src/llamafactory/hparams/model_args.py QuantizationArguments
+    """
+
+    quantization_method: Optional[str] = Field(
+        None,
+        description="Quantization method: bnb, gptq, awq, aqlm, quanto, eetq, hqq, mxfp4, fp8",
+    )
+    quantization_bit: Optional[int] = Field(
+        None,
+        description="Number of bits for on-the-fly quantization (e.g. 4 or 8)",
+    )
+    quantization_type: Optional[Literal["nf4", "fp4"]] = Field(
+        None,
+        description="Quantization data type for bitsandbytes int4 training: nf4 or fp4",
+    )
+    double_quantization: Optional[bool] = Field(
+        None,
+        description="Whether to use double quantization in bitsandbytes int4 training",
+    )
+
+    def get_non_none_dict(self) -> dict:
+        """Return only the non-None fields as a dict, for merging into other configs."""
+        return {k: v for k, v in self.model_dump().items() if v is not None}
 
 
 class TrainSftArgs(BaseConfigModel):
@@ -190,6 +224,10 @@ class TrainSftArgs(BaseConfigModel):
     plot_loss: bool = Field(True, description="Whether to plot loss curve")
     fp16: bool = Field(True, description="Whether to use fp16")
     flash_attn: str = Field("fa2", description="Flash Attention type")
+    quantization: QuantizationArgs = Field(
+        default_factory=QuantizationArgs,
+        description="Quantization settings for on-the-fly quantization (QLoRA, etc.)",
+    )
     preprocessing_num_workers: int = Field(16, description="Number of preprocessing worker processes")
     dataloader_num_workers: int = Field(4, description="Number of dataloader worker processes")
     deepspeed: Optional[str] = Field(
@@ -207,6 +245,12 @@ class InferArgs(BaseConfigModel):
 
 class VllmArgs(BaseConfigModel):
     gpu_memory_utilization: float = Field(default=0.9, description="vllm GPU memory utilization")
+    quantization: Optional[str] = Field(
+        default=None, description="Quantization method for vLLM, e.g. 'awq', 'gptq'"
+    )
+    load_format: Optional[str] = Field(
+        default=None, description="Format for loading weights, e.g. 'awq', 'gptq'"
+    )
 
 
 class TestModelArgs(BaseConfigModel):
@@ -235,7 +279,7 @@ class WcConfig(BaseModel):
 
 
 class WCInferConfig(CommonArgs, InferArgs):
-    """Final configuration model for Web Demo"""
+    """Final configuration model for Web Demo / API Service (based on LLaMA-Factory ChatModel)"""
 
     pass
 

--- a/weclone/utils/config_models.py
+++ b/weclone/utils/config_models.py
@@ -163,7 +163,6 @@ class MakeDatasetArgs(BaseConfigModel):
     )
     clean_batch_size: int = Field(10, description="Batch size for data cleaning")
     vision_api: VisionApiConfig = Field(VisionApiConfig())
-    pure_text: bool = Field(False, description="Whether to use pure text mode (disable vision encoder)")
 
 
 class QuantizationArgs(BaseConfigModel):

--- a/weclone/utils/tools.py
+++ b/weclone/utils/tools.py
@@ -1,7 +1,8 @@
 def dict_to_argv(d):
     argv = []
     for k, v in d.items():
+        if v is None:
+            continue
         argv.append("--" + k)
-        if v is not None:
-            argv.append(str(v))
+        argv.append(str(v))
     return argv


### PR DESCRIPTION
## Summary by Sourcery

添加与 LLaMA-Factory 对齐的可配置量化支持，将其贯穿到训练和推理配置中，并改进测试和文档的易用性。

New Features:
- 引入 `QuantizationArgs` 模型，以与 LLaMA-Factory 保持一致的方式配置量化选项。
- 在 `TrainSftArgs` 和 `VllmArgs` 中暴露量化设置，用于训练和基于 vLLM 的推理。

Enhancements:
- 在构建训练和推理配置时，将嵌套的量化参数展开为顶层参数，以符合 LLaMA-Factory 的预期。
- 在将配置字典转换为 `argv` 时，避免传递值为 `None` 的 CLI 参数。
- 明确数据集关系和 Web Demo API 用法相关的配置文档字符串及描述。
- 确保 SFT 训练使用清理后的配置字典，省略冗余的嵌套量化字段。
- 在运行模型评估测试之前添加 API 服务器可用性检查。

Documentation:
- 从英文和中文 README 中移除过时的在线微调和赞助相关章节。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable quantization support aligned with LLaMA-Factory, propagate it through training and inference configs, and improve test and documentation ergonomics.

New Features:
- Introduce QuantizationArgs model to configure quantization options consistently with LLaMA-Factory.
- Expose quantization settings in TrainSftArgs and VllmArgs for training and vLLM-based inference.

Enhancements:
- Flatten nested quantization parameters into top-level arguments when building train and infer configs so they match LLaMA-Factory expectations.
- Avoid passing None-valued CLI arguments when converting config dicts to argv.
- Clarify configuration docstrings and descriptions for dataset relations and web demo API usage.
- Ensure SFT training runs with a cleaned config dict that omits redundant nested quantization fields.
- Add an API server availability check before running model evaluation tests.

Documentation:
- Remove outdated online fine-tuning and sponsorship sections from the English and Chinese READMEs.

</details>