### PR TITLE
docs: fix zh README config template path

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -93,7 +93,7 @@ uv pip install https://github.com/explosion/spacy-models/releases/download/zh_co
 
 3.将配置文件模板复制一份并重命名为`settings.jsonc`，后续配置修改在此文件进行：
 ```bash
-cp settings.template.jsonc settings.jsonc
+cp examples/tg.template.jsonc settings.jsonc
 ```
 - 微调**多模态模型**时，请使用[examples/mllm.template.jsonc](https://github.com/xming521/WeClone/blob/master/examples/mllm.template.jsonc)作为配置文件。
 


### PR DESCRIPTION
## Summary\n- fix the config template copy command in README_zh.md\n- align the Chinese setup instructions with the English README and the existing Telegram template path\n\n## Why\nThe Chinese README currently tells users to copy , but the English README and the documented Telegram setup use . This small docs fix reduces setup confusion and keeps the two READMEs consistent.\n\n## Verification\n- verified  now contains

## Summary by Sourcery

文档：
- 修正 README_zh.md 中的配置模板复制命令，使其指向用于 `settings.jsonc` 的 Telegram 示例模板。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Correct the config template copy command in README_zh.md to point to the Telegram example template for settings.jsonc.

</details>