### PR TITLE
fix: update star history chart to use star-history.dera.page

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,6 @@ This disclaimer may be revised with project updates, users should regularly chec
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=xming521/WeClone&type=Date)](https://www.star-history.com/#xming521/WeClone&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=xming521/WeClone&type=Date)](https://star-history.dera.page/#xming521/WeClone&Date)
 
 </div>

--- a/README_zh.md
+++ b/README_zh.md
@@ -321,7 +321,7 @@ BUPT VCIS Lab的支持
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=xming521/WeClone&type=Date)](https://www.star-history.com/#xming521/WeClone&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=xming521/WeClone&type=Date)](https://star-history.dera.page/#xming521/WeClone&Date)
 
 </div>
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions, so the stars no longer display. This PR points the chart and its link to the star-history.dera.page service, which uses an alternative data source that requires no API token. The chart now renders correctly again.

## Summary by Sourcery

文档：
- 将英文和中文版 README 中的 star 历史图表链接从原来的 star-history.com 更新为指向 star-history.dera.page。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update English and Chinese README star history chart URLs to point to star-history.dera.page instead of the previous star-history.com endpoint.

</details>