### PR TITLE
fix: support Telegram Desktop full exports (#188)

### DIFF
--- a/tests/test_telegram_parser.py
+++ b/tests/test_telegram_parser.py
@@ -1,0 +1,100 @@
+import json
+from types import SimpleNamespace
+
+from weclone.data.chat_parsers.telegram_parser import process_telegram_dataset
+
+
+def make_config():
+    return SimpleNamespace(
+        telegram_args=SimpleNamespace(my_id="user-1"),
+        include_type=[],
+    )
+
+
+def test_process_full_telegram_export(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    export_dir = tmp_path / "dataset" / "telegram" / "ChatExport"
+    export_dir.mkdir(parents=True)
+    (export_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "chats": {
+                    "list": [
+                        {
+                            "name": "Alice",
+                            "type": "personal_chat",
+                            "id": 101,
+                            "messages": [
+                                {
+                                    "id": 1,
+                                    "type": "message",
+                                    "date": "2025-01-01T12:00:00",
+                                    "from": "me",
+                                    "from_id": "user-1",
+                                    "text": "hello",
+                                }
+                            ],
+                        },
+                        {
+                            "name": "Team",
+                            "type": "group",
+                            "id": 202,
+                            "messages": [
+                                {
+                                    "id": 2,
+                                    "type": "message",
+                                    "date": "2025-01-01T12:01:00",
+                                    "from": "Alice",
+                                    "from_id": "user-2",
+                                    "text": [{"type": "plain", "text": "hi"}],
+                                }
+                            ],
+                        },
+                    ]
+                }
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    process_telegram_dataset(make_config())
+
+    alice_csv = tmp_path / "dataset" / "csv" / "Alice-personal_chat-101" / "Alice-personal_chat-101.csv"
+    team_csv = tmp_path / "dataset" / "csv" / "Team-group-202" / "Team-group-202.csv"
+    assert alice_csv.exists()
+    assert team_csv.exists()
+    assert "hello" in alice_csv.read_text(encoding="utf-8")
+    assert "hi" in team_csv.read_text(encoding="utf-8")
+
+
+def test_process_individual_chat_export(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    export_dir = tmp_path / "dataset" / "telegram" / "SingleChat"
+    export_dir.mkdir(parents=True)
+    (export_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "name": "Bob",
+                "type": "personal_chat",
+                "id": 303,
+                "messages": [
+                    {
+                        "id": 1,
+                        "type": "message",
+                        "date": "2025-01-01T12:00:00",
+                        "from": "Bob",
+                        "from_id": "user-3",
+                        "text": "hello from Bob",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    process_telegram_dataset(make_config())
+
+    output = tmp_path / "dataset" / "csv" / "Bob-personal_chat-303" / "Bob-personal_chat-303.csv"
+    assert output.exists()
+    assert "hello from Bob" in output.read_text(encoding="utf-8")

--- a/weclone/data/chat_parsers/telegram_parser.py
+++ b/weclone/data/chat_parsers/telegram_parser.py
@@ -282,15 +282,33 @@ class TelegramChatParser:
         logger.info(f"Image copying completed: successful {copied_count}, skipped {skipped_count}")
 
 
+def _iter_export_chats(jdata: Dict):
+    """Yield chat objects from both Telegram export layouts.
+
+    Telegram Desktop's full export wraps chats in ``{"chats": {"list": [...]}}``
+    while an individual chat export contains ``name`` and ``messages`` at the
+    top level. Keeping the normalization here lets the downstream parser use
+    the same chat-level contract for both formats.
+    """
+    chats = jdata.get("chats")
+    if isinstance(chats, dict) and isinstance(chats.get("list"), list):
+        yield from (chat for chat in chats["list"] if isinstance(chat, dict))
+    else:
+        yield jdata
+
+
+def _safe_path_component(value: object, fallback: str) -> str:
+    component = "".join(c for c in str(value) if c.isalnum() or c in "._-")
+    return component or fallback
+
+
 def process_telegram_dataset(config: WCMakeDatasetConfig) -> None:
     """
-    Process Telegram dataset, traverse all folders under dataset/telegram
-    Create corresponding folders for each telegram folder under dataset/csv
+    Process individual or full Telegram Desktop exports under ``dataset/telegram``.
 
-    Parameters
-    ----------
-    config : WCMakeDatasetConfig
-        Dataset configuration, contains telegram_args.my_id for determining sender
+    Each folder may contain either an individual chat ``result.json`` with
+    top-level ``messages`` or a full export whose chats are stored in
+    ``chats.list``. Every chat is written to its own CSV directory.
     """
     telegram_dir = "dataset/telegram"
     csv_output_dir = "dataset/csv"
@@ -311,33 +329,36 @@ def process_telegram_dataset(config: WCMakeDatasetConfig) -> None:
             else:
                 os.remove(item_path)
 
+    parser = TelegramChatParser(config=config)
     for folder_name in os.listdir(telegram_dir):
         folder_path = os.path.join(telegram_dir, folder_name)
         if not os.path.isdir(folder_path):
             continue
 
         json_path = os.path.join(folder_path, "result.json")
+        if not os.path.isfile(json_path):
+            logger.warning(f"Folder '{folder_name}' does not contain result.json, skipping")
+            continue
 
         with open(json_path, "r", encoding="utf-8") as file:
             jdata = json.load(file)
 
-        chat_name = jdata.get("name", "unknown")
-        chat_type = jdata.get("type", "unknown")
-        chat_id = jdata.get("id", "unknown")
+        export_chats = list(_iter_export_chats(jdata))
+        for chat_index, chat_data in enumerate(export_chats, start=1):
+            chat_name = chat_data.get("name", f"{folder_name}-{chat_index}")
+            chat_type = chat_data.get("type", "unknown")
+            chat_id = chat_data.get("id", chat_index)
 
-        safe_name = "".join(c for c in str(chat_name) if c.isalnum() or c in "._-")
-        safe_type = "".join(c for c in str(chat_type) if c.isalnum() or c in "._-")
-        safe_id = "".join(c for c in str(chat_id) if c.isalnum() or c in "._-")
+            safe_name = _safe_path_component(chat_name, f"chat-{chat_index}")
+            safe_type = _safe_path_component(chat_type, "unknown")
+            safe_id = _safe_path_component(chat_id, str(chat_index))
+            csv_folder_name = f"{safe_name}-{safe_type}-{safe_id}"
+            csv_folder_path = os.path.join(csv_output_dir, csv_folder_name)
 
-        csv_folder_name = f"{safe_name}-{safe_type}-{safe_id}"
-        csv_folder_path = os.path.join(csv_output_dir, csv_folder_name)
-
-        parser = TelegramChatParser(config=config)
-        messages = parser.process_chat(jdata)
-
-        if messages:
-            csv_file_path = os.path.join(csv_folder_path, f"{csv_folder_name}.csv")
-            parser.to_csv(messages, csv_file_path)
-            parser.copy_received_images(messages, folder_path)
-        else:
-            logger.warning(f"Folder '{folder_name}' has no valid messages")
+            messages = parser.process_chat(chat_data)
+            if messages:
+                csv_file_path = os.path.join(csv_folder_path, f"{csv_folder_name}.csv")
+                parser.to_csv(messages, csv_file_path)
+                parser.copy_received_images(messages, folder_path)
+            else:
+                logger.warning(f"Chat '{chat_name}' in folder '{folder_name}' has no valid messages")


### PR DESCRIPTION
Closes #188. Support Telegram Desktop full exports with chats.list while preserving compatibility with individual chat exports. Add regression tests for both formats.

## Sourcery 摘要

支持 Telegram Desktop 完整导出和单个聊天导出，并为每个聊天生成独立的 CSV 数据集。

新功能：
- 支持处理包含多个聊天的 Telegram Desktop 完整导出，其中聊天数据位于 `chats.list` 中。
- 继续支持顶层包含聊天数据的单个 Telegram 聊天导出。

增强功能：
- 为每个导出的聊天生成独立且经过清理的 CSV 输出路径，并跳过不包含结果文件的文件夹。

测试：
- 增加对 Telegram 完整导出和单个聊天导出的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support both Telegram Desktop full exports and individual chat exports while producing separate CSV datasets for each chat.

New Features:
- Support processing Telegram Desktop full exports containing multiple chats in `chats.list`.
- Continue supporting individual Telegram chat exports with top-level chat data.

Enhancements:
- Generate separate sanitized CSV output paths for each exported chat and skip folders without a result file.

Tests:
- Add regression coverage for full Telegram exports and individual chat exports.

</details>