### PR TITLE
docs: add Mac Apple Silicon fine-tuning notes (#187)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ More Parameter Details: [Data Preprocessing](https://docs.weclone.love/docs/depl
 weclone-cli train-sft
 ```
 
+> [!NOTE]
+> **Mac Device (Apple Silicon) Fine-tuning Notes**:
+> - LlamaFactory supports training using Mac's MPS (Metal Performance Shaders). No additional configuration is needed, PyTorch will automatically recognize the MPS device.
+> - `flash-attn` **cannot be installed** on Mac (FlashAttention only supports NVIDIA GPUs). Therefore, please ensure you change `flash_attn` in `train_sft_args` within `settings.jsonc` from the default `"fa2"` to `"sdpa"` or `"auto"` to prevent the training command from crashing.
+> - Limited by Mac's unified memory, it is recommended to appropriately reduce `per_device_train_batch_size` and `cutoff_len` based on your machine's unified memory size (accounting for other applications' usage).
+
 ### Multi-GPU Training
 Uncomment the `deepspeed` line in `settings.jsonc` and use the following command for multi-GPU training:
 ```bash

--- a/README_zh.md
+++ b/README_zh.md
@@ -143,6 +143,12 @@ weclone-cli make-dataset
 weclone-cli train-sft
 ```
 
+> [!NOTE]
+> **Mac 设备（Apple Silicon）微调注意事项**：
+> - LlamaFactory 支持使用 Mac 的 MPS（Metal Performance Shaders）进行训练，无需额外配置，PyTorch 会自动识别 MPS 设备。
+> - Mac 上**无法安装** `flash-attn`（FlashAttention 仅支持 NVIDIA GPU），因此请确保在 `settings.jsonc` 的 `train_sft_args` 中将 `flash_attn` 从默认的 `"fa2"` 修改为 `"sdpa"` 或 `"auto"`，以避免训练命令崩溃。
+> - 受限于 Mac 的统一内存，建议根据机型统一内存大小（需考虑其他应用占用）适当调小 `per_device_train_batch_size` 和 `cutoff_len`。
+
 ### 多卡训练
 取消`settings.jsonc`中`deepspeed`行代码注释，使用以下命令多卡训练：
 ```bash


### PR DESCRIPTION
Closes #187. Added notes for Mac (Apple Silicon) users regarding MPS support, flash-attention limitations, and memory tuning recommendations in both English and Chinese READMEs.

## Sourcery 摘要

文档：
- 添加英文和中文 README 指南，介绍如何在 Apple Silicon Mac 上进行微调，包括 MPS 支持、FlashAttention 的限制以及内存调优建议。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

文档：
- 添加英文和中文 README 指南，介绍如何在 Apple Silicon Mac 上进行微调，涵盖 MPS 支持、FlashAttention 替代方案以及统一内存调优建议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add English and Chinese README guidance for fine-tuning on Apple Silicon Macs, covering MPS support, FlashAttention alternatives, and unified-memory tuning recommendations.

</details>

</details>